### PR TITLE
RobotInterfaceの修正

### DIFF
--- a/sample/fullset_robot_robotinterface.yaml
+++ b/sample/fullset_robot_robotinterface.yaml
@@ -25,7 +25,7 @@ joint_groups:
 
 devices:
   -
-    topic: /fullset_robot/TOF_sensor0/value
+    topic: /fullset_robot/TOF_Sensor0/value
     type: std_msgs/Float64
     name: TOF_sensor0
     rate: 10

--- a/src/irsl_choreonoid_ros/RobotInterface.py
+++ b/src/irsl_choreonoid_ros/RobotInterface.py
@@ -164,9 +164,11 @@ class DeviceInterface(object):
         for dev in device_list:
             self.devices[dev['name']] = RosDevice(dev)
 
-    def data(self, name):
+    def wait_newdata(self, name):
         while not self.devices[name].is_new:
             time.sleep(0.001)
+
+    def data(self, name):
         self.devices[name].is_new = False
         dev = self.devices[name]
         return dev.current_msg

--- a/src/irsl_choreonoid_ros/RobotInterface.py
+++ b/src/irsl_choreonoid_ros/RobotInterface.py
@@ -1,8 +1,6 @@
 import yaml
 import sys
 import os
-import threading
-import time
 
 # ROS
 import rospy
@@ -53,7 +51,6 @@ class MobileBaseInterface(object):
 
     def move_trajectory(self, traj):
         pass
-    
 
 class JointGroupTopic(object):
     def __init__(self, group, body=None):
@@ -149,11 +146,9 @@ class RosDevice(object):
         self.msg = eval('{}'.format(tp[1]))
 
         self.sub = rospy.Subscriber(self.topic, self.msg, self.callback)
-        self.is_new = False
 
     def callback(self, msg):
         self.current_msg = msg
-        self.is_new = True
         ## TODO: update robot-model
 
 class DeviceInterface(object):
@@ -164,12 +159,7 @@ class DeviceInterface(object):
         for dev in device_list:
             self.devices[dev['name']] = RosDevice(dev)
 
-    def wait_newdata(self, name):
-        while not self.devices[name].is_new:
-            time.sleep(0.001)
-
     def data(self, name):
-        self.devices[name].is_new = False
         dev = self.devices[name]
         return dev.current_msg
 
@@ -226,25 +216,9 @@ class RobotInterface(object):
             return
 
         self.devices = DeviceInterface(self.info['devices'], body=self.body)
-    
-    
-    def spin(self):
-        try:
-            rospy.spin()
-        except rospy.ROSInterruptException: pass
-
-    def run(self):
-        self.thread = threading.Thread(target=self.spin)
-        self.thread.start()
-    
-    def stop(self):
-        self.thread.join()
-
-        
 
 # from irsl_choreonoid_ros.RobotInterface import RobotInterface
 # ri = RobotInterface('robot_interface.yaml')
-# ri.run()
 # robot_model = ri.copyRobotModel()
 # ri.mobile_base.move_velocity(1, 0, 0)
 # av = robot_model.angleVector()

--- a/src/irsl_choreonoid_ros/RobotInterface.py
+++ b/src/irsl_choreonoid_ros/RobotInterface.py
@@ -149,9 +149,11 @@ class RosDevice(object):
         self.msg = eval('{}'.format(tp[1]))
 
         self.sub = rospy.Subscriber(self.topic, self.msg, self.callback)
+        self.is_new = False
 
     def callback(self, msg):
         self.current_msg = msg
+        self.is_new = True
         ## TODO: update robot-model
 
 class DeviceInterface(object):
@@ -163,6 +165,9 @@ class DeviceInterface(object):
             self.devices[dev['name']] = RosDevice(dev)
 
     def data(self, name):
+        while not self.devices[name].is_new:
+            time.sleep(0.001)
+        self.devices[name].is_new = False
         dev = self.devices[name]
         return dev.current_msg
 
@@ -220,8 +225,6 @@ class RobotInterface(object):
 
         self.devices = DeviceInterface(self.info['devices'], body=self.body)
     
-    def update(self, tm=0.01):
-        time.sleep(tm)
     
     def spin(self):
         try:

--- a/src/irsl_choreonoid_ros/RobotInterface.py
+++ b/src/irsl_choreonoid_ros/RobotInterface.py
@@ -219,13 +219,16 @@ class RobotInterface(object):
 
         self.devices = DeviceInterface(self.info['devices'], body=self.body)
     
-    def update(self):
+    def update(self, tm=0.01):
+        time.sleep(tm)
+    
+    def spin(self):
         try:
             rospy.spin()
         except rospy.ROSInterruptException: pass
 
     def run(self):
-        self.thread = threading.Thread(target=self.update)
+        self.thread = threading.Thread(target=self.spin)
         self.thread.start()
     
     def stop(self):

--- a/src/irsl_choreonoid_ros/RobotInterface.py
+++ b/src/irsl_choreonoid_ros/RobotInterface.py
@@ -2,6 +2,7 @@ import yaml
 import sys
 import os
 import threading
+import time
 
 # ROS
 import rospy


### PR DESCRIPTION
TOFデータの読み込みと台車制御ができるように修正しました．
以下のサンプルコードが動くところまで確認しました．

rospy.spin()を実行しないとSubscriberが動かないため，RobotInterfaceでthreadを作成しrospy.spin()を実施するようにしたのですが，あっておりますか？

```
from irsl_choreonoid_ros.RobotInterface import RobotInterface
import time


ri = RobotInterface('file:///userdir/fullset_robot_robotinterface.yaml')
ri.run()

robot_model = ri.copyRobotModel()

av = robot_model.angleVector()
print(av)
ri.joint_groups.sendAngleVector(av, 2.0)

time.sleep(1.0)
data = ri.devices.data('TOF_sensor0')
print(data)

ri.mobile_base.move_velocity(0, -0.05, 0)
time.sleep(1.0)
ri.mobile_base.stop()

data = ri.devices.data('TOF_sensor0')
print(data)

```