### PR TITLE
default joint groupにから車輪jointを削除

### DIFF
--- a/python/generate_ri_config.py
+++ b/python/generate_ri_config.py
@@ -31,6 +31,7 @@ if __name__=='__main__':
     parser.add_argument('--bodyfile', type=str, default="robotname.body")
     parser.add_argument('--use_wheel', type=strtobool, default=False)
     parser.add_argument('--controller_name', type=str, default="joint_controller")
+    parser.add_argument('--wheeljoints', nargs="*", type=str, default=[])
     
     args = parser.parse_args()
     fname = args.bodyfile
@@ -75,7 +76,7 @@ if __name__=='__main__':
     print("    topic: /{}/{}/command".format(robotname,args.controller_name))
     print("    # type: 'action' or 'command'")
     print("    type: command")
-    print("    joint_names: {}".format([j.jointName for j in joint_list]))
+    print("    joint_names: {}".format([j.jointName for j in joint_list if j.jointName not in args.wheeljoints]))
     print("")
     print("devices:")
     print("  -")

--- a/scripts/generate_settings.sh
+++ b/scripts/generate_settings.sh
@@ -76,5 +76,10 @@ if [ $wheel_length -gt 0 ] ; then
 fi
 
 rosrun irsl_choreonoid_ros generate_cnoid.py --bodyfile $BODYFILE --templatefile $CHOREONOID_DIR_PATH/../share/irsl_choreonoid_ros/config/choreonoid_ros_template.cnoid > $CNOIDFILE
+
+if [ $wheel_length -gt 0 ] ; then
+rosrun irsl_choreonoid_ros generate_ri_config.py --bodyfile $BODYFILE --use_wheel $USE_WHEEL --wheeljoints ${WHEEL_LIST[@]}  > $RICONFIGFILE
+else
 rosrun irsl_choreonoid_ros generate_ri_config.py --bodyfile $BODYFILE --use_wheel $USE_WHEEL > $RICONFIGFILE
+fi
 rosrun irsl_choreonoid_ros generate_roslaunch.py --bodyfile $BODYFILE  --urdffile $URDFFILE --cnoidfile $CNOIDFILE --roscontrolfile $ROSCONTROLFILE --use_wheel $USE_WHEEL --controllers "$CONTROLLERS_LIST" > run_sim_robot.launch 


### PR DESCRIPTION
RI設定ファイルのdefault joint groupにすべてのjoint nameが設定されていたが, 車輪として使うものを削除する．