### PR TITLE
自動生成スクリプトの空行を削除

### DIFF
--- a/python/generate_ros_settings.py
+++ b/python/generate_ros_settings.py
@@ -1,6 +1,4 @@
-
 #!/usr/bin/python3
-
 
 if __name__=='__main__':
     print("robot_ip_addr: 'XXX.XXX.XXX.XXX' # input raspberry pi IP address")


### PR DESCRIPTION
先頭行が空行のためShebangが読み込めずrosrunで実行が実行できなかったため修正．